### PR TITLE
Add `Found corrupted kerninfo!` workaround for A8X/A9X

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The `amd64` iso is for 64-bit CPUs (AMD and Intel) and the `i686` one is for 32-
 3. Open balenaEtcher and write the `.iso` you downloaded to your USB drive.
 4. Reboot, enter your BIOS's boot menu and select the USB drive.
 
+# Checkra1n (A8X/A9X)
+
+Due to a checkra1n bug, the checkra1n option will give `Found corrupting kerninfo` after booting into the checkra1n apple logo screen on A8X/A9X devices. Use this option to workaround this bug.
+
 # Odysseyra1n
 ## What's odysseyra1n
 Odysseyra1n lets you install on a checkra1ned device

--- a/build.sh
+++ b/build.sh
@@ -189,6 +189,13 @@ mkdir -p work/chroot/root/odysseyra1n/
       https://cdn.discordapp.com/attachments/672628720497852459/990614139925852160/dtbpack \
       https://cdn.discordapp.com/attachments/672628720497852459/990620143803588689/Pongo.bin
 )
+
+# Download A8X/A9X resources
+(
+    cd work/chroot/root
+    curl -L -O https://cdn.discordapp.com/attachments/672628720497852459/1025048286916251668/PongoConsolidated.bin
+)
+
 # Configure autologin
 mkdir -p work/chroot/etc/systemd/system/getty@tty1.service.d
 cat << EOF > work/chroot/etc/systemd/system/getty@tty1.service.d/override.conf

--- a/scripts/odysseyn1x_menu
+++ b/scripts/odysseyn1x_menu
@@ -9,13 +9,14 @@ whiptail_width="$(($(tput cols) - 20))"
 while true; do
   CHOICE="$(whiptail --nocancel --title "Odysseyn1x $ODYSSEYN1X_VERSION" --menu '' $whiptail_height $whiptail_width 8 \
     '1' 'Checkra1n' \
-    '2' 'Odysseyra1n' \
-    '3' 'Project Sandcastle' \
-    '4' 'Linux on Apple' \
-    '5' 'SSH' \
-    '6' 'Shell' \
-    '7' 'Shut down' \
-    '8' 'Reboot' 3>&1 1>&2 2>&3)"
+    '2' 'Checkra1n (A8X/A9X)' \
+    '3' 'Odysseyra1n' \
+    '4' 'Project Sandcastle' \
+    '5' 'Linux on Apple' \
+    '6' 'SSH' \
+    '7' 'Shell' \
+    '8' 'Shut down' \
+    '9' 'Reboot' 3>&1 1>&2 2>&3)"
   case "$CHOICE" in
     1)
       clear
@@ -23,28 +24,32 @@ while true; do
       ;;
     2)
       clear
-      /usr/bin/odysseyra1n
+      /usr/bin/checkra1n -k /root/PongoConsolidated.bin
       ;;
     3)
-      /usr/bin/projectsandcastle_menu
+      clear
+      /usr/bin/odysseyra1n
       ;;
     4)
-      /usr/bin/linux-apple_menu
+      /usr/bin/projectsandcastle_menu
       ;;
     5)
-      clear
-      /usr/bin/ssh_into_ios
+      /usr/bin/linux-apple_menu
       ;;
     6)
       clear
-      break
+      /usr/bin/ssh_into_ios
       ;;
     7)
+      clear
+      break
+      ;;
+    8)
       odysseyn1x_logo
       sleep 2
       /usr/sbin/shutdown now
       ;;
-    8)
+    9)
       odysseyn1x_logo
       sleep 2
       /usr/sbin/reboot


### PR DESCRIPTION
Due to an upstream checkra1n bug, the `Found corrupted kerninfo!` message will appear in pongoOS and the jailbreak will stop. This PR adds a workaround for it.